### PR TITLE
Renaming Machine Character Limit

### DIFF
--- a/src/main/java/ml/pkom/advancedreborn/tile/RenamingMachineTile.java
+++ b/src/main/java/ml/pkom/advancedreborn/tile/RenamingMachineTile.java
@@ -68,7 +68,11 @@ public class RenamingMachineTile extends PowerAcceptorBlockEntity implements ITo
     }
 
     public void setName(@Nullable String name) {
-        this.name = name;
+        if (name != null && name.length() > 30) {
+            this.name = name.substring(0, 30);
+        } else {
+            this.name = name;
+        }
     }
 
     public void setNameClient(@Nullable String name) {


### PR DESCRIPTION
Renaming Machine now has a character limit of 30 (not in the GUI, when naming it will be shortened)